### PR TITLE
fix: use implicitWidth/implicitHeight in horizontalBarPill to prevent icon overlap

### DIFF
--- a/ScreenRecorder.qml
+++ b/ScreenRecorder.qml
@@ -133,8 +133,8 @@ PluginComponent {
 
     horizontalBarPill: Component {
         Item {
-            width: pillRow.width
-            implicitHeight: pillRow.height || 24
+            implicitWidth: pillRow.implicitWidth
+            implicitHeight: pillRow.implicitHeight || 24
 
             MouseArea {
                 anchors.fill: parent


### PR DESCRIPTION
## Problem

When recording starts, the timer text becomes visible in the horizontal bar pill, causing it to overflow and overlap adjacent bar icons.

## Root Cause

`BasePill` (the framework layer) computes its visual width by reading `contentLoader.item.implicitWidth`. The pill root `Item` was binding `width: pillRow.width` but never setting `implicitWidth`, so `BasePill` always saw `implicitWidth = 0`. The pill container never expanded, but the content did — causing overflow.

## Fix

Bind `implicitWidth` and `implicitHeight` on the root `Item` to `pillRow`'s implicit sizes instead of explicit sizes. This matches the established pattern used by other DMS plugins (e.g. DankActions).

```qml
// Before
Item {
    width: pillRow.width
    implicitHeight: pillRow.height || 24

// After
Item {
    implicitWidth: pillRow.implicitWidth
    implicitHeight: pillRow.implicitHeight || 24
```