### PR TITLE
Post-record Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Open **DMS Settings → Plugins → Screen Recorder**:
 | **Record cursor** | Include mouse pointer | On |
 | **Capture source** | `portal` = choose window/screen on start; `screen` = first monitor | portal |
 | **Recordings folder** | Output directory (empty = `~/Videos/Screencasting`) | — |
+| **Post-record command** | Command to run after recording finishes (file path appended as last arg) | — |
 
 ## How stopping works
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,19 @@ Open **DMS Settings → Plugins → Screen Recorder**:
 | **Record cursor** | Include mouse pointer | On |
 | **Capture source** | `portal` = choose window/screen on start; `screen` = first monitor | portal |
 | **Recordings folder** | Output directory (empty = `~/Videos/Screencasting`) | — |
-| **Post-record command** | Command to run after recording finishes (file path appended as last arg) | — |
+| **Post-record command** | Command to run after recording finishes. Use `$1` to reference the file path. | — |
+
+### Post-record command examples
+
+| Goal | Setting value |
+|------|---------------|
+| Copy `file://` URI to clipboard | `wl-copy --type text/uri-list "file://$1"` |
+| Open file with `dragon-drop` | `dragon-drop "$1"` |
+| Open in `mpv` | `mpv "$1"` |
+| Copy raw path to clipboard | `wl-copy "$1"` |
+| Run a custom script | `~/.local/bin/my-script "$1"` |
+
+The file path is available as `$1` and is fully expanded (e.g. `~/Videos/Screencasting/2026-06-13_09-00-00.mp4`).
 
 ## How stopping works
 

--- a/ScreenRecorderService.qml
+++ b/ScreenRecorderService.qml
@@ -165,9 +165,10 @@ PluginComponent {
                     }
                 }
                 if (root._stopRequested && root._currentOutputFile) {
-                    var postCmd = pluginService.loadPluginData(pluginId, "postRecordCommand", "") || ""
+                    var postCmd = root.pluginService.loadPluginData(root.pluginId, "postRecordCommand", "") || ""
                     if (postCmd) {
-                        Quickshell.execDetached(["sh", "-c", postCmd + " \"" + root._currentOutputFile.replace(/"/g, '\\"') + "\""])
+                        var path = root._currentOutputFile
+                        Quickshell.execDetached(["sh", "-c", "set -- \"" + path.replace(/"/g, '\\"') + "\"; " + postCmd])
                     }
                 }
                 root._stopRequested = false

--- a/ScreenRecorderService.qml
+++ b/ScreenRecorderService.qml
@@ -21,6 +21,7 @@ PluginComponent {
     property int recordTimerSeconds: 0
     property bool _stopRequested: false
     property bool _cooldown: false
+    property string _currentOutputFile: ""
 
     Component.onCompleted: {
         if (pluginService) {
@@ -73,7 +74,16 @@ PluginComponent {
         var dir = (root.outputDir || "").replace(/\/$/, "") || "${XDG_VIDEOS_DIR:-$HOME/Videos}/Screencasting"
         var cursorFlag = root.recordCursor ? "yes" : "no"
         var audioFlags = root.recordAudio ? " -ac opus -a default_output" : ""
-        var script = "if ! command -v gpu-screen-recorder >/dev/null 2>&1; then exit 127; fi; DIR=\"" + dir.replace(/"/g, '\\"') + "\"; mkdir -p \"$DIR\"; FILE=\"$DIR/$(date +'%Y-%m-%d_%H-%M-%S').mp4\"; exec gpu-screen-recorder -w " + root.captureSource + " -f " + root.fps + " -k h264" + audioFlags + " -q " + root.quality + " -cursor " + cursorFlag + " -cr limited -o \"$FILE\""
+        var now = new Date()
+        var dateStr = now.getFullYear() + '-' +
+            ('0' + (now.getMonth() + 1)).slice(-2) + '-' +
+            ('0' + now.getDate()).slice(-2) + '_' +
+            ('0' + now.getHours()).slice(-2) + '-' +
+            ('0' + now.getMinutes()).slice(-2) + '-' +
+            ('0' + now.getSeconds()).slice(-2)
+        var fileName = dateStr + '.mp4'
+        root._currentOutputFile = dir + '/' + fileName
+        var script = "if ! command -v gpu-screen-recorder >/dev/null 2>&1; then exit 127; fi; DIR=\"" + dir.replace(/"/g, '\\"') + "\"; mkdir -p \"$DIR\"; exec gpu-screen-recorder -w " + root.captureSource + " -f " + root.fps + " -k h264" + audioFlags + " -q " + root.quality + " -cursor " + cursorFlag + " -cr limited -o \"$DIR/" + fileName + "\""
         var proc = recorderProcessComponent.createObject(root, { procCommand: ["sh", "-c", script] })
         proc.running = true
         root.recordState = "recording"
@@ -154,7 +164,14 @@ PluginComponent {
                         ToastService.showError("Recording crashed or was cancelled. Exit code: " + exitCode)
                     }
                 }
+                if (root._stopRequested && root._currentOutputFile) {
+                    var postCmd = pluginService.loadPluginData(pluginId, "postRecordCommand", "") || ""
+                    if (postCmd) {
+                        Quickshell.execDetached(["sh", "-c", postCmd + " \"" + root._currentOutputFile.replace(/"/g, '\\"') + "\""])
+                    }
+                }
                 root._stopRequested = false
+                root._currentOutputFile = ""
                 destroy()
             }
         }

--- a/ScreenRecorderService.qml
+++ b/ScreenRecorderService.qml
@@ -82,7 +82,7 @@ PluginComponent {
             ('0' + now.getMinutes()).slice(-2) + '-' +
             ('0' + now.getSeconds()).slice(-2)
         var fileName = dateStr + '.mp4'
-        root._currentOutputFile = dir + '/' + fileName
+        root._currentOutputFile = (dir + '/' + fileName).trim()
         var script = "if ! command -v gpu-screen-recorder >/dev/null 2>&1; then exit 127; fi; DIR=\"" + dir.replace(/"/g, '\\"') + "\"; mkdir -p \"$DIR\"; exec gpu-screen-recorder -w " + root.captureSource + " -f " + root.fps + " -k h264" + audioFlags + " -q " + root.quality + " -cursor " + cursorFlag + " -cr limited -o \"$DIR/" + fileName + "\""
         var proc = recorderProcessComponent.createObject(root, { procCommand: ["sh", "-c", script] })
         proc.running = true
@@ -165,7 +165,7 @@ PluginComponent {
                     }
                 }
                 if (root._stopRequested && root._currentOutputFile) {
-                    var postCmd = root.pluginService.loadPluginData(root.pluginId, "postRecordCommand", "") || ""
+                    var postCmd = (root.pluginService.loadPluginData(root.pluginId, "postRecordCommand", "") || "").trim()
                     if (postCmd) {
                         var path = root._currentOutputFile
                         Quickshell.execDetached(["sh", "-c", "set -- \"" + path.replace(/"/g, '\\"') + "\"; " + postCmd])

--- a/Settings.qml
+++ b/Settings.qml
@@ -82,7 +82,7 @@ PluginSettings {
         settingKey: "postRecordCommand"
         label: "Post-record command"
         description: "Command to run after recording finishes. The file path is passed as the last argument."
-        placeholder: "dragon-drop"
+        placeholder: "dragon-drop $1"
         defaultValue: ""
     }
 

--- a/Settings.qml
+++ b/Settings.qml
@@ -78,6 +78,14 @@ PluginSettings {
         defaultValue: ""
     }
 
+    StringSetting {
+        settingKey: "postRecordCommand"
+        label: "Post-record command"
+        description: "Command to run after recording finishes. The file path is passed as the last argument."
+        placeholder: "dragon-drop"
+        defaultValue: ""
+    }
+
     StyledRect {
         width: parent.width
         height: controlsColumn.implicitHeight + Theme.spacingL * 2

--- a/plugin.json
+++ b/plugin.json
@@ -1,21 +1,15 @@
 {
-  "id": "screenRecorder",
-  "name": "Screen Recorder",
-  "description": "Start, stop, and configure screen captures with gpu-screen-recorder on any Wayland compositor",
-  "version": "1.2.0",
-  "author": "arqueon",
-  "icon": "videocam",
-  "type": "launcher",
-  "component": "./ScreenRecorderService.qml",
-  "settings": "./Settings.qml",
-  "capabilities": [
-    "dankbar-widget",
-    "control-center"
-  ],
-  "permissions": [
-    "settings_read",
-    "settings_write",
-    "process"
-  ],
-  "requires_dms": ">=1.2.0"
+	"id": "screenRecorder",
+	"name": "Screen Recorder",
+	"description": "Start, stop, and configure screen captures with gpu-screen-recorder on any Wayland compositor",
+	"version": "1.3.0",
+	"author": "arqueon",
+	"icon": "videocam",
+	"type": "launcher",
+	"component": "./ScreenRecorderService.qml",
+	"settings": "./Settings.qml",
+	"capabilities": ["dankbar-widget", "control-center"],
+	"permissions": ["settings_read", "settings_write", "process"],
+	"requires_dms": ">=1.2.0"
 }
+


### PR DESCRIPTION
Adds a new `postRecordCommand` setting that lets users run an arbitrary
command after a recording finishes, with the file path available as `$1`.

Changes:
- **ScreenRecorderService.qml**: Generate the output file path in QML
  (matching the existing `date` format) so it can be tracked. After the
  gpu-screen-recorder process exits on an intentional stop, execute the
  configured command via `sh -c` with the path expanded and set as `$1`.
- **Settings.qml**: Add `StringSetting` for `postRecordCommand`.
- **README.md**: Document the setting with usage examples.
- **plugin.json**: Bump version to 1.3.0.

Usage: `dragon-drop "$1"`, `wl-copy --type text/uri-list "file://$1"`, etc.

Addresses #9 