### PR TITLE
feat: add Control Center widget

### DIFF
--- a/ScreenRecorder.qml
+++ b/ScreenRecorder.qml
@@ -12,6 +12,15 @@ PluginComponent {
 
     property bool _pendingStop: false
 
+    ccWidgetIcon: recordState === "idle" ? "videocam" : (recordState === "paused" ? "play_circle" : "stop_circle")
+    ccWidgetPrimaryText: "Screen Recorder"
+    ccWidgetSecondaryText: {
+        if (recordState === "idle") return "Ready"
+        const status = recordState === "paused" ? "Paused" : "Recording"
+        return status + " " + _formatTime(recordTimerSeconds)
+    }
+    ccWidgetIsActive: recordState !== "idle"
+
     function _formatTime(totalSeconds) {
         var m = Math.floor(totalSeconds / 60)
         var s = totalSeconds % 60
@@ -25,6 +34,8 @@ PluginComponent {
     function startRecording() { callRecorder("startRecording") }
     function stopRecording() { callRecorder("stopRecording") }
     function togglePause() { callRecorder("togglePause") }
+
+    onCcWidgetToggled: callRecorder("toggleRecording")
 
     PluginGlobalVar {
         id: recordStateGlobal


### PR DESCRIPTION
Re-enables the Control Center widget

This was originally removed after issue https://github.com/arqueon/dms-screen-recorder/issues/3 - in commit  https://github.com/arqueon/dms-screen-recorder/commit/b16153fbbd3010edf0fcf3f290e4601c4498f6c1. 

Testing with current DMS and niri did not reproduce the original issue.
I am able to see the permission modal and it stays around until I approve or cancel.

Tested with

- DMS: v1.5.1
- niri: v26.04
- gpu-screen-recorder v5.12.5
- Fedora 44
- Wayland